### PR TITLE
Studomat missing year fix

### DIFF
--- a/app/src/main/java/com/tstudioz/fax/fme/feature/studomat/repository/StudomatRepository.kt
+++ b/app/src/main/java/com/tstudioz/fax/fme/feature/studomat/repository/StudomatRepository.kt
@@ -6,7 +6,6 @@ import com.tstudioz.fax.fme.feature.studomat.data.parseCurrentYear
 import com.tstudioz.fax.fme.feature.studomat.data.parseStudent
 import com.tstudioz.fax.fme.feature.studomat.data.parseYears
 import com.tstudioz.fax.fme.feature.studomat.data.sortedByNameAndSemester
-import com.tstudioz.fax.fme.feature.studomat.models.StudomatSubject
 import com.tstudioz.fax.fme.feature.studomat.models.StudomatYear
 import com.tstudioz.fax.fme.feature.studomat.models.StudomatYearInfo
 import com.tstudioz.fax.fme.feature.studomat.repository.models.StudomatRepositoryResult
@@ -24,8 +23,6 @@ class StudomatRepository(
         return when (val result = studomatService.getYearNames()) {
             is NetworkServiceResult.StudomatResult.Success -> {
                 val resultGetYears = parseYears(result.data)
-                studomatDao.deleteYears()
-                studomatDao.insertYears(resultGetYears)
                 Log.d("StudomatRepository", "getYears: $resultGetYears")
                 StudomatRepositoryResult.StudentAndYearsResult.Success(resultGetYears, student)
             }


### PR DESCRIPTION
the studomat logs in even if the studomat tab is not opened, to speed up data fetching, but it saves incomplete yearInfo as the last step of login (this is a tiny bit wrong but okay) into room. if the subjects are not fetched after login, on the next app opening it loads the year info with missing info, it is visible in courseName which is the title of the year. By removing the saving of data it fixes the bug.